### PR TITLE
views: Fix Broken Table Sorting

### DIFF
--- a/assignment/myapp/templates/myapp/display_statuses.html
+++ b/assignment/myapp/templates/myapp/display_statuses.html
@@ -32,16 +32,16 @@ Date:     22/09/23
         <tbody>
             {% for item in items %}
                 <tr scope="row">
-                    <td> {{item.status.status_name}} </td>
+                    <td> {{item.status_name}} </td>
                     <td> {{item.reporter}} </td>
-                    <td> <a href="/view_status/{{item.status.status_name}}"> View </a> </td>
+                    <td> <a href="/view_status/{{item.status_name}}"> View </a> </td>
                     {% if item.can_update %}
-                    <td> <a href="/update_status/{{item.status.status_name}}"> Update </a> </td>
+                    <td> <a href="/update_status/{{item.status_name}}"> Update </a> </td>
                     {% else %}
                     <td>Cannot Update</td>
                     {% endif %}
                     {% if user.is_superuser %}
-                    <td> <a href="/delete_status/{{item.status.status_name}}"> Delete </a> </td>
+                    <td> <a href="/delete_status/{{item.status_name}}"> Delete </a> </td>
                     {% endif %}
                 </tr>
             {% endfor %}

--- a/assignment/myapp/templates/myapp/display_tickets.html
+++ b/assignment/myapp/templates/myapp/display_tickets.html
@@ -35,20 +35,20 @@ Date:     22/09/23
         <tbody>
             {% for item in items %}
                 <tr scope="row">
-                    <td> {{item.ticket.ticket_id}} </td>
-                    <td> {{item.ticket.ticket_title}} </td>
-                    <td> {{item.ticket.assignee}} </td>
+                    <td> {{item.ticket_id}} </td>
+                    <td> {{item.ticket_title}} </td>
+                    <td> {{item.assignee}} </td>
                     <td> {{item.reporter}} </td>
-                    <td> {{item.ticket.type}} </td>
-                    <td> {{item.ticket.status}} </td>
-                    <td> <a href="/view_ticket/{{item.ticket.ticket_id}}"> Link </a> </td>
+                    <td> {{item.type}} </td>
+                    <td> {{item.status}} </td>
+                    <td> <a href="/view_ticket/{{item.ticket_id}}"> Link </a> </td>
                     {% if item.can_update %}
-                    <td> <a href="/update_ticket/{{item.ticket.ticket_id}}"> Update </a> </td>
+                    <td> <a href="/update_ticket/{{item.ticket_id}}"> Update </a> </td>
                     {% else %}
                     <td>Cannot Update</td>
                     {% endif %}
                     {% if user.is_superuser %}
-                    <td> <a href="/delete_ticket/{{item.ticket.ticket_id}}"> Delete </a> </td>
+                    <td> <a href="/delete_ticket/{{item.ticket_id}}"> Delete </a> </td>
                     {% endif %}
                 </tr>
             {% endfor %}

--- a/assignment/myapp/templates/myapp/display_types.html
+++ b/assignment/myapp/templates/myapp/display_types.html
@@ -31,16 +31,16 @@ Date:     22/09/23
         <tbody>
             {% for item in items %}
                 <tr scope="row">
-                    <td> {{item.ticket_type.type_name}} </td>
+                    <td> {{item.type_name}} </td>
                     <td> {{item.reporter}} </td>
-                    <td> <a href="/view_type/{{item.ticket_type.type_name}}"> View </a> </td>
+                    <td> <a href="/view_type/{{item.type_name}}"> View </a> </td>
                     {% if item.can_update %}
-                    <td> <a href="/update_type/{{item.ticket_type.type_name}}"> Update </a> </td>
+                    <td> <a href="/update_type/{{item.type_name}}"> Update </a> </td>
                     {% else %}
                     <td>Cannot Update</td>
                     {% endif %}
                     {% if user.is_superuser %}
-                    <td> <a href="/delete_type/{{item.ticket_type.type_name}}"> Delete </a> </td>
+                    <td> <a href="/delete_type/{{item.type_name}}"> Delete </a> </td>
                     {% endif %}
                 </tr>
             {% endfor %}

--- a/assignment/myapp/views.py
+++ b/assignment/myapp/views.py
@@ -263,9 +263,15 @@ def ViewTickets(request):
 
         can_update = can_user_update_ticket(request, ticket)
 
-        items.append({"ticket": ticket, "reporter": reporter, "can_update": can_update})
+        items.append({"ticket_id": ticket.ticket_id,
+                      "ticket_title": ticket.ticket_title,
+                      "assignee": ticket.assignee,
+                      "reporter": reporter,
+                      "ticket_type": ticket.type,
+                      "status": ticket.status ,
+                      "can_update": can_update})
 
-    return render(request, "myapp/display_tickets.html", {"items": items})
+    return render(request, "myapp/display_tickets.html", {"items": sorted(items, key=lambda i:i["ticket_id"])})
 
 
 @login_required(login_url="/login")
@@ -324,8 +330,12 @@ def ViewStatuses(request):
 
         can_update = can_user_update(request, status)
 
-        items.append({"status": status, "reporter": reporter, "can_update": can_update})
-    return render(request, "myapp/display_statuses.html", {"items": items})
+        items.append({
+            "status_name": status.status_name,
+            "reporter": reporter,
+            "can_update": can_update
+        })
+    return render(request, "myapp/display_statuses.html", {"items": sorted(items, key=lambda i:i["status_name"])})
 
 
 @login_required(login_url="/login")
@@ -375,10 +385,10 @@ def ViewTypes(request):
         can_update = can_user_update(request, ticket_type)
 
         items.append(
-            {"ticket_type": ticket_type, "reporter": reporter, "can_update": can_update}
+            {"type_name": ticket_type.type_name, "reporter": reporter, "can_update": can_update}
         )
 
-    return render(request, "myapp/display_types.html", {"items": items})
+    return render(request, "myapp/display_types.html", {"items": sorted(items, key=lambda i:i["type_name"])})
 
 
 @login_required(login_url="/login")


### PR DESCRIPTION
Since the change to PostgreSQL, the tables have not been sorting correctly due to how the updating works. This fixes it and sorts the tables by either ID or Alphabetically.