### PR TITLE
tests: Add --keepdb for test runs in CI

### DIFF
--- a/.github/workflows/post_merge.yml
+++ b/.github/workflows/post_merge.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         cd assignment/
         python manage.py collectstatic
-        python manage.py test
+        python manage.py test --keepdb test_software_engineering_l6_data
     - name: Deploy Webpage
       run: | 
         echo "deploy"

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -33,4 +33,4 @@ jobs:
       run: |
         cd assignment/
         python manage.py collectstatic
-        python manage.py test
+        python manage.py test --keepdb test_software_engineering_l6_data


### PR DESCRIPTION
This ensures that when CI runs, it does not make a new test database, rather keeps the exisiting one that is on the remote server.